### PR TITLE
Removed `Face::id` field

### DIFF
--- a/src/Face.cu
+++ b/src/Face.cu
@@ -1,5 +1,3 @@
-#include <utility>
-
 #include "Face.cuh"
 #include "MapNode.cuh"
 #include "Polyhedron.cuh"

--- a/src/Face.cu
+++ b/src/Face.cu
@@ -1,3 +1,5 @@
+#include <utility>
+
 #include "Face.cuh"
 #include "MapNode.cuh"
 #include "Polyhedron.cuh"
@@ -9,15 +11,15 @@ __device__ SpacePoint calculate_normal(const SpacePoint *vertices)
     return normal / get_distance(normal, origin);
 }
 
-__device__ Face::Face(int id, const SpacePoint *vertices, int n_of_vertices) :
-        id(id), vertices(malloc_and_copy(vertices, n_of_vertices)), n_of_vertices(n_of_vertices),
+__device__ Face::Face(const SpacePoint *vertices, int n_of_vertices) :
+        vertices(malloc_and_copy(vertices, n_of_vertices)), n_of_vertices(n_of_vertices),
         normal(calculate_normal(vertices)), node(nullptr)
 {
 
 }
 
 __device__ Face::Face(const Face &other) :
-        id(other.id), vertices(malloc_and_copy(other.vertices, other.n_of_vertices)),
+        vertices(malloc_and_copy(other.vertices, other.n_of_vertices)),
         n_of_vertices(other.n_of_vertices),
         normal(other.normal), node(other.node)
 {
@@ -32,7 +34,7 @@ __device__ Face::~Face()
 
 __device__ void Face::set_node(MapNode *node, Polyhedron *polyhedron)
 {
-    if(polyhedron->find_face_id_by_point(node->get_coordinates()) == id)
+    if(*this == *polyhedron->find_face_by_point(node->get_coordinates()))
     {
         this->node = node;
     }
@@ -41,12 +43,6 @@ __device__ void Face::set_node(MapNode *node, Polyhedron *polyhedron)
 __device__ MapNode *Face::get_node() const
 {
     return node;
-}
-
-
-__device__ int Face::get_id() const
-{
-    return id;
 }
 
 __device__ const SpacePoint *Face::get_vertices() const
@@ -67,5 +63,18 @@ __device__ SpacePoint Face::get_normal() const
 
 __host__ __device__ bool operator==(const Face &a, const Face &b)
 {
-    return a.id == b.id;
+    if(a.n_of_vertices != b.n_of_vertices)
+        return false;
+
+    for(int i = 0; i < a.n_of_vertices; ++i)
+    {
+        if(a.vertices[i] != b.vertices[i])
+            return false;
+    }
+    return true;
+}
+
+__host__ __device__ bool operator!=(const Face &a, const Face &b)
+{
+    return !(a == b);
 }

--- a/src/Face.cuh
+++ b/src/Face.cuh
@@ -26,18 +26,16 @@ public:
     /**
      * Creates a `Face` object
      *
-     * @param id Identifier of the polyhedron face
      * @param vertices Array of polyhedron vertices that belong to the face.
      *      Must be ordered in a special way (see note below)
      * @param n_of_vertices Number of vertices on the face
-     * @param node Some node laying on the face
      *
      * @note The vertices order. Looking on a face <b>from outside</b> the polyhedron, some vertex (let's call it A)
      * must be saved to vertices[0]. It's neighbour clockwise - vertex B (B is next to A clockwise) must be saved to
      * vertices[1] and so on. Assuming there are N vertices in total, A's neighbors are B clockwise and
      * X counterclockwise, X must be saved to vertices[N - 2], and A must be saved <b>again</b> to vertices[N - 1]
      */
-    __device__ Face(int id, const SpacePoint *vertices, int n_of_vertices);
+    __device__ Face(const SpacePoint *vertices, int n_of_vertices);
 
     /// `Face` object copy constructor
     __device__ Face(const Face &other);
@@ -62,8 +60,6 @@ public:
      */
     __device__ MapNode *get_node() const;
 
-    __device__ int get_id() const;
-
     __device__ const SpacePoint *get_vertices() const;
 
     __device__ int get_n_of_vertices() const;
@@ -72,21 +68,21 @@ public:
 
 
     /**
-     * Checks whether two `Face`s are same (checked using ids)
+     * Checks whether two `Face`s are same (<b>and</b> have same vertices order)
      *
-     * @param a `Face` object
-     * @param b `Face` object
+     * @param a `Face` to be compared
+     * @param b `Face` to be compared
      *
-     * @returns `true` if two faces have same ids, `false` otherwise
+     * @returns `true` if two faces have same vertices sets and same vertices order, `false` otherwise
+     *
+     * @note As mentioned in the brief description, this is not a mathematical comparison of two faces. It only returns
+     *      `true` if the vertices have the same vertices order, starting from the same one
      */
     __host__ __device__ friend bool operator==(const Face &a, const Face &b);
 
 private:
     /// Pointer to some node laying on the face
     MapNode *node;
-
-    /// An identifier of the face of a `Polyhedron`
-    int id;
 
     /// Array of vertices that belong to the face (represented as described in the constructor)
     const SpacePoint *vertices;
@@ -97,6 +93,20 @@ private:
     /// Normal to the face
     SpacePoint normal;
 };
+
+
+/**
+ * Checks whether two `Face`s are same (and have same vertices order)
+ *
+ * @param a `Face` to be compared
+ * @param b `Face` to be compared
+ *
+ * @returns `false` if two faces have same vertices sets and same vertices order, `true` otherwise
+ *
+ * @note As mentioned in the brief description, this is not a mathematical comparison of two faces. It only returns
+ *      `false` if the vertices have the same vertices order, starting from the same one
+ */
+__host__ __device__ bool operator!=(const Face &a, const Face &b);
 
 
 #endif //MIND_S_CRAWL_FACE_CUH

--- a/src/MapNode.cu
+++ b/src/MapNode.cu
@@ -3,7 +3,7 @@
 #include "Polyhedron.cuh"
 
 
-__device__ MapNode::MapNode(Polyhedron *const polyhedron, Face *polyhedron_face, SpacePoint coordinates) :
+__device__ MapNode::MapNode(Polyhedron *polyhedron, Face *polyhedron_face, SpacePoint coordinates) :
         polyhedron(polyhedron), trail(0), contains_food(false), coordinates(coordinates),
         polyhedron_face(polyhedron_face), left(nullptr), top(nullptr), right(nullptr), bottom(nullptr)
 {}

--- a/src/MapNode.cu
+++ b/src/MapNode.cu
@@ -3,9 +3,9 @@
 #include "Polyhedron.cuh"
 
 
-__device__ MapNode::MapNode(Polyhedron *const polyhedron, int polyhedron_face_id, SpacePoint coordinates) :
+__device__ MapNode::MapNode(Polyhedron *const polyhedron, Face *polyhedron_face, SpacePoint coordinates) :
         polyhedron(polyhedron), trail(0), contains_food(false), coordinates(coordinates),
-        polyhedron_face_id(polyhedron_face_id), left(nullptr), top(nullptr), right(nullptr), bottom(nullptr)
+        polyhedron_face(polyhedron_face), left(nullptr), top(nullptr), right(nullptr), bottom(nullptr)
 {}
 
 __device__ MapNode::~MapNode()
@@ -90,9 +90,9 @@ __device__ Polyhedron *MapNode::get_polyhedron() const
     return polyhedron;
 }
 
-__device__ int MapNode::get_face_id() const
+__device__ Face *MapNode::get_face() const
 {
-    return polyhedron_face_id;
+    return polyhedron_face;
 }
 
 

--- a/src/MapNode.cuh
+++ b/src/MapNode.cuh
@@ -4,6 +4,7 @@
 
 #include "common.cuh"
 #include "SpacePoint.cuh"
+#include "Face.cuh"
 
 class Particle;
 
@@ -23,10 +24,10 @@ public:
      * Creates a `MapNode` object
      *
      * @param polyhedron Pointer to the polyhedron to create node on
-     * @param polyhedron_face_id The polyhedron's face to create node on
+     * @param polyhedron_face The polyhedron's face to create node on
      * @param coordinates Coordinates of node to create node at
      */
-    __device__ MapNode(Polyhedron *polyhedron, int polyhedron_face_id, SpacePoint coordinates);
+    __device__ MapNode(Polyhedron *const polyhedron, Face *polyhedron_face, SpacePoint coordinates);
 
     /// Forbids copying `MapNode` objects
     __host__ __device__ MapNode(const MapNode &) = delete;
@@ -41,7 +42,7 @@ public:
         swap(right, other.right);
         swap(top, other.top);
         swap(bottom, other.bottom);
-        swap(polyhedron_face_id, other.polyhedron_face_id);
+        swap(polyhedron_face, other.polyhedron_face);
         swap(coordinates, other.coordinates);
         swap(contains_food, other.contains_food);
         swap(particle, other.particle);
@@ -162,13 +163,13 @@ public:
     __device__ Polyhedron *get_polyhedron() const;
 
     /**
-     * Returns the id of face the node is laying on
+     * Returns pointer to the face the node is laying on
      *
-     * @returns The id of face the node belongs to
+     * @returns Pointer to the face the node belongs to
      *
      * @note This parameter is never ever changed during the existence of the object
      */
-    __device__ int get_face_id() const;
+    __device__ Face *get_face() const;
 
 
     /**
@@ -257,8 +258,8 @@ private:
     /// Polyhedron containing the node
     Polyhedron *polyhedron;
 
-    /// Polyhedron's face the node is located on
-    int polyhedron_face_id;
+    /// Pointer to the polyhedron's face the node is located on
+    Face *polyhedron_face;
 
     /// The node's coordinates
     SpacePoint coordinates;

--- a/src/MapNode.cuh
+++ b/src/MapNode.cuh
@@ -27,7 +27,7 @@ public:
      * @param polyhedron_face The polyhedron's face to create node on
      * @param coordinates Coordinates of node to create node at
      */
-    __device__ MapNode(Polyhedron *const polyhedron, Face *polyhedron_face, SpacePoint coordinates);
+    __device__ MapNode(Polyhedron *polyhedron, Face *polyhedron_face, SpacePoint coordinates);
 
     /// Forbids copying `MapNode` objects
     __host__ __device__ MapNode(const MapNode &) = delete;

--- a/src/Particle.cu
+++ b/src/Particle.cu
@@ -63,6 +63,7 @@ __device__ void Particle::do_sensory_behaviours()
 
     double trail_l = find_nearest_mapnode(p, rotate_point_from_agent(m_sensor_direction, -jc::sa,
                                                                      true), map_node)->trail;
+    // Rotate 0 radians is not useless! The `rotate_point_from_agent` also projects vector to polyhedron's surface
     double trail_m = find_nearest_mapnode(p, rotate_point_from_agent(m_sensor_direction, 0,
                                                                      true), map_node)->trail;
     double trail_r = find_nearest_mapnode(p, rotate_point_from_agent(m_sensor_direction, jc::sa,

--- a/src/Polyhedron.cuh
+++ b/src/Polyhedron.cuh
@@ -27,13 +27,13 @@ public:
 
 
     /**
-     * Finds a face that the point belongs to
+     * Finds a face the given point belongs to
      *
      * @param point Point in space
      *
-     * @returns Identifier of the found face
+     * @returns Pointer to the found face
      */
-    __device__ int find_face_id_by_point(SpacePoint point) const;
+    __device__ Face *find_face_by_point(SpacePoint point) const;
 
 
     /// Pointer-represented array of polyhedron faces
@@ -58,15 +58,15 @@ __device__ bool does_edge_belong_to_face(SpacePoint a, SpacePoint b, const Face 
 
 /**
  * Finds a face adjacent to the given face along the edge represented by vertices
- * with indexes `vertex_id` and `vertex_id + 1 in `Face::vertices` array
+ * with indexes `vertex_id` and `vertex_id + 1` in `Face::vertices` array
  *
  * @param vertex_id Index of edge vertex in `Face::vertices` array
- * @param current_face_id Identifier of given face
+ * @param current_face Pointer to the face to search next to
  * @param polyhedron The polyhedron in simulation
  *
- * @returns Identifier of the found face
+ * @returns Pointer to the found face
  */
-__device__ int find_face_next_to_edge(int vertex_id, int current_face_id, Polyhedron *polyhedron);
+__device__ Face *find_face_next_to_edge(int vertex_id, Face *current_face, Polyhedron *polyhedron);
 
 /**
  * Returns the intersection point of segment AB with an edge of given face if it exists, point B otherwise
@@ -92,12 +92,12 @@ __device__ SpacePoint find_intersection_with_edge(SpacePoint a, SpacePoint b, Fa
  *
  * @param a The beginning of vector AB, point A
  * @param b The end of vector AB, point B
- * @param current_face_id Identifier of the face point A belongs to
+ * @param current_face Pointer to the face point A belongs to
  * @param polyhedron The polyhedron in simulation
  *
  * @returns Coordinates of the end of AB vector's overlay
  */
-__device__ SpacePoint get_projected_vector_end(SpacePoint a, SpacePoint b, int current_face_id, Polyhedron *polyhedron);
+__device__ SpacePoint get_projected_vector_end(SpacePoint a, SpacePoint b, Face *current_face, Polyhedron *polyhedron);
 
 
 #endif //MIND_S_CRAWL_POLYHEDRON_CUH

--- a/src/fucking_shit.cu
+++ b/src/fucking_shit.cu
@@ -140,16 +140,16 @@ __device__ MapNode *find_nearest_mapnode_greedy(const SpacePoint &dest, MapNode 
 __device__ MapNode *find_nearest_mapnode(const Polyhedron *const polyhedron, const SpacePoint &dest,
                                          MapNode *const start)
 {
-    int dest_face = polyhedron->find_face_id_by_point(dest);
+    Face *dest_face = polyhedron->find_face_by_point(dest);
 
     if(start != nullptr)
     {
         MapNode *ans = find_nearest_mapnode_greedy(dest, start);
-        if(ans->get_face_id() == dest_face)
+        if(*ans->get_face() == *dest_face)
             return ans;
     }
 
-    return find_nearest_mapnode_greedy(dest, polyhedron->faces[polyhedron->find_face_id_by_point(dest)].get_node());
+    return find_nearest_mapnode_greedy(dest, polyhedron->find_face_by_point(dest)->get_node());
 }
 
 

--- a/src/fucking_shit.cu
+++ b/src/fucking_shit.cu
@@ -12,7 +12,7 @@ namespace jc = jones_constants;
 
 [[nodiscard]] __device__ bool create_particle(MapNode *node)
 {
-    auto p = new Particle(node, rand0to1() * 360);
+    auto p = new Particle(node, rand0to1() * 2 * M_PI);
 
     if(node->attach_particle(p))
         return true;
@@ -149,7 +149,7 @@ __device__ MapNode *find_nearest_mapnode(const Polyhedron *const polyhedron, con
             return ans;
     }
 
-    return find_nearest_mapnode_greedy(dest, polyhedron->find_face_by_point(dest)->get_node());
+    return find_nearest_mapnode_greedy(dest, dest_face->get_node());
 }
 
 


### PR DESCRIPTION
The field was attracting bugs and missuses (for example, comparison with `id`s) and moreover useless (in the meaning that it can be safely removed from the code with some fixes applied so that we neither lose performance nor code readability), so I removed it

(PR also contains some other minor improvements)