### PR TITLE
Creating the correct grid of nodes parallel to the cube edges

### DIFF
--- a/src/Polyhedron.cu
+++ b/src/Polyhedron.cu
@@ -83,7 +83,8 @@ __host__ __device__ double Polyhedron::calculate_square_of_surface()
     double square = 0;
     for(int i = 0; i < n_of_faces; ++i)
     {
-        for(int j = 1; j < faces[i].get_n_of_vertices() - 1; ++j)
+        // Cause first vertex of face repeats again in the end the condition is `j < faces[i].get_n_of_vertices() - 2`
+        for(int j = 1; j < faces[i].get_n_of_vertices() - 2; ++j)
         {
             SpacePoint a = faces[i].get_vertices()[j] - faces[i].get_vertices()[0];
             SpacePoint b = faces[i].get_vertices()[j + 1] - faces[i].get_vertices()[0];
@@ -152,12 +153,12 @@ __host__ __device__ SpacePoint get_projected_vector_end(SpacePoint a, SpacePoint
                                                      polyhedron)->get_normal();
     SpacePoint moving_vector = (b - a) / get_distance(a, b);
 
-    double phi_cos = normal_after * normal_before;
+    double phi_cos = (-1) * normal_after * normal_before;
     double phi_sin = sin(acos(phi_cos));
     double alpha_cos = moving_vector * (normal_before % normal_after);
 
     SpacePoint faced_vector_direction = (normal_before + normal_after * phi_cos) * sin(acos(alpha_cos)) / phi_sin +
-            (normal_before % normal_after) * alpha_cos / phi_sin;
+                                        (normal_before % normal_after) * alpha_cos / phi_sin;
 
     // If vector AB does not intersect any edge of face, `intersection` equals `b`,
     // so `faced_vector_direction` does not affect at all

--- a/src/Polyhedron.cu
+++ b/src/Polyhedron.cu
@@ -86,10 +86,11 @@ __host__ __device__ double Polyhedron::calculate_square_of_surface()
         // Cause first vertex of face repeats again in the end the condition is `j < faces[i].get_n_of_vertices() - 2`
         for(int j = 1; j < faces[i].get_n_of_vertices() - 2; ++j)
         {
-            SpacePoint a = faces[i].get_vertices()[j] - faces[i].get_vertices()[0];
-            SpacePoint b = faces[i].get_vertices()[j + 1] - faces[i].get_vertices()[0];
+            SpacePoint a = faces[i].get_vertices()[j + 1] - faces[i].get_vertices()[0];
+            SpacePoint b = faces[i].get_vertices()[j] - faces[i].get_vertices()[0];
 
-            double sign_of_square = (b % a) * faces[i].get_normal() / abs((b % a) * faces[i].get_normal());
+            double sign_of_square = (a % b) * faces[i].get_normal();
+            sign_of_square /= abs(sign_of_square);
             square += sign_of_square * (a ^ b) / 2;
         }
     }

--- a/src/Polyhedron.cu
+++ b/src/Polyhedron.cu
@@ -78,6 +78,24 @@ __host__ __device__ int Polyhedron::get_n_of_faces() const
 }
 
 
+__host__ __device__ double Polyhedron::calculate_square_of_surface()
+{
+    double square = 0;
+    for(int i = 0; i < n_of_faces; ++i)
+    {
+        for(int j = 1; j < faces[i].get_n_of_vertices() - 1; ++j)
+        {
+            SpacePoint a = faces[i].get_vertices()[j] - faces[i].get_vertices()[0];
+            SpacePoint b = faces[i].get_vertices()[j + 1] - faces[i].get_vertices()[0];
+
+            double sign_of_square = (b % a) * faces[i].get_normal() / abs((b % a) * faces[i].get_normal());
+            square += sign_of_square * (a ^ b) / 2;
+        }
+    }
+    return square;
+}
+
+
 __host__ __device__ bool does_edge_belong_to_face(SpacePoint a, SpacePoint b, const Face *face)
 {
     bool flag1 = false, flag2 = false;

--- a/src/Polyhedron.cu
+++ b/src/Polyhedron.cu
@@ -59,7 +59,7 @@ __host__ __device__ Face *Polyhedron::find_face_by_point(SpacePoint point) const
     for(int i = 0; i < n_of_faces; ++i)
     {
         Face *face = &faces[i];
-        SpacePoint normal = (face->get_vertices()[1] - face->get_vertices()[0]) % (point - face->get_vertices()[0]);
+        SpacePoint normal = (point - face->get_vertices()[0]) % (face->get_vertices()[1] - face->get_vertices()[0]);
         normal = normal / get_distance(normal, origin);
         if(normal * face->get_normal() >= 1 - eps)
             return face;
@@ -148,9 +148,9 @@ __host__ __device__ SpacePoint get_projected_vector_end(SpacePoint a, SpacePoint
     int intersection_edge_vertex_id = 0;
     SpacePoint intersection = find_intersection_with_edge(a, b, current_face, &intersection_edge_vertex_id);
 
-    SpacePoint normal_before = current_face->get_normal();
-    SpacePoint normal_after = find_face_next_to_edge(intersection_edge_vertex_id, current_face,
-                                                     polyhedron)->get_normal();
+    SpacePoint normal_before = (-1) * current_face->get_normal();
+    SpacePoint normal_after = (-1) * find_face_next_to_edge(intersection_edge_vertex_id, current_face,
+                                                            polyhedron)->get_normal();
     SpacePoint moving_vector = (b - a) / get_distance(a, b);
 
     double phi_cos = (-1) * normal_after * normal_before;

--- a/src/Polyhedron.cuh
+++ b/src/Polyhedron.cuh
@@ -70,6 +70,16 @@ public:
     __host__ __device__ int get_n_of_faces() const;
 
 
+    /**
+     * Calculates square of polyhedron surface using signed areas
+     *
+     * @note Supports all types of polyhedron
+     *
+     * @returns Square of polyhedron surface
+     */
+    __host__ __device__ double calculate_square_of_surface();
+
+
 private:
     /// Pointer-represented array of polyhedron faces
     Face *faces;

--- a/src/SimulationMap.cu
+++ b/src/SimulationMap.cu
@@ -24,7 +24,7 @@ __device__ SimulationMap::SimulationMap(Polyhedron *polyhedron) :
 {
     /*
      * Maximum number of nodes
-     * It must be greater or equal than real number of nodes (`n_of_nodes`) after creation node grid
+     * It must be greater than or equal to the real number of nodes (`n_of_nodes`) after creation node grid
      */
     int max_number_of_nodes = 2 * polyhedron->calculate_square_of_surface() / (mapnode_dist * mapnode_dist);
 
@@ -37,15 +37,8 @@ __device__ SimulationMap::SimulationMap(Polyhedron *polyhedron) :
     nodes = (MapNode *)malloc(sizeof(MapNode) * max_number_of_nodes);
     nodes[0] = MapNode(polyhedron, start_face, start_node_coordinates);
     n_of_nodes = 1;
-    /*
-    // Direction vector from first node to its top neighbor sets randomly
-    double dir_angle = M_PI / 3;
-    SpacePoint direction_vector = relative_point_rotation(start_node_coordinates, start_face->get_vertices()[0],
-                                                          start_face->get_normal(), M_PI * 2 * rand0to1() * 0 + dir_angle)
-                                  - start_node_coordinates;
-    */
 
-    // Direction vector parallel to the vertical edges of cube.
+    // Direction vector parallel to the vertical edges of cube
     SpacePoint direction_vector = {0, 0, 1};
     /**
      * Array of direction vectors from nodes with the same index

--- a/src/SimulationMap.cu
+++ b/src/SimulationMap.cu
@@ -37,12 +37,16 @@ __device__ SimulationMap::SimulationMap(Polyhedron *polyhedron) :
     nodes = (MapNode *)malloc(sizeof(MapNode) * max_number_of_nodes);
     nodes[0] = MapNode(polyhedron, start_face, start_node_coordinates);
     n_of_nodes = 1;
-
+    /*
     // Direction vector from first node to its top neighbor sets randomly
+    double dir_angle = M_PI / 3;
     SpacePoint direction_vector = relative_point_rotation(start_node_coordinates, start_face->get_vertices()[0],
-                                                          start_face->get_normal(), M_PI * 2 * rand0to1())
+                                                          start_face->get_normal(), M_PI * 2 * rand0to1() * 0 + dir_angle)
                                   - start_node_coordinates;
+    */
 
+    // Direction vector parallel to the vertical edges of cube.
+    SpacePoint direction_vector = {0, 0, 1};
     /**
      * Array of direction vectors from nodes with the same index
      * as in `SimulationMap::nodes` array to their top neighbors

--- a/src/SimulationMap.cu
+++ b/src/SimulationMap.cu
@@ -33,13 +33,16 @@ __device__ SimulationMap::SimulationMap(Polyhedron *polyhedron) :
     Face *start_face = &polyhedron->get_faces()[0];
     SpacePoint start_node_coordinates = (start_face->get_vertices()[0] + start_face->get_vertices()[1] +
                                          start_face->get_vertices()[2]) / 3;
+
     nodes = (MapNode *)malloc(sizeof(MapNode) * max_number_of_nodes);
     nodes[0] = MapNode(polyhedron, start_face, start_node_coordinates);
     n_of_nodes = 1;
 
     // Direction vector from first node to its top neighbor sets randomly
     SpacePoint direction_vector = relative_point_rotation(start_node_coordinates, start_face->get_vertices()[0],
-                                                          start_face->get_normal(), M_PI * 2 * rand0to1());
+                                                          start_face->get_normal(), M_PI * 2 * rand0to1())
+                                  - start_node_coordinates;
+
     /**
      * Array of direction vectors from nodes with the same index
      * as in `SimulationMap::nodes` array to their top neighbors

--- a/src/SimulationMap.cuh
+++ b/src/SimulationMap.cuh
@@ -118,12 +118,12 @@ private:
      *
      * @param current_node_id Index of the node whose neighbor was searched
      * @param neighbor_node_id Index of neighbor node
-     * @param nodes_directions Pointer to the array of direction vectors to the top neighbor node from each node
+     * @param nodes_directions Array of direction vectors to the top neighbor node from each node
      * @param angle Angle between the top neighbor node and the neighbor node whose index is searched
      *              relative to current node, clockwise is positive direction
      */
     __device__ void set_direction_to_top_neighbor(int current_node_id, int neighbor_node_id,
-                                                  SpacePoint **nodes_directions, double angle) const;
+                                                  SpacePoint *nodes_directions, double angle) const;
 
 
     /**
@@ -140,7 +140,7 @@ private:
      * Returns `-1` if node cannot be created and `create_new_nodes` is `true`
      *
      * @param current_node_id Index of the node whose neighbor is searched
-     * @param nodes_directions Pointer to the array of direction vectors to the top neighbor node from each node
+     * @param nodes_directions Array of direction vectors to the top neighbor node from each node
      * @param angle Angle between the top neighbor node and the neighbor node whose index is searched
      *              relative to current node, clockwise is positive direction
      * @param does_face_have_nodes Boolean array whether the faces have nodes or not
@@ -148,7 +148,7 @@ private:
      *
      * @returns The index of neighbor node if it has existed or was created, `-1` otherwise
      */
-    __device__ int get_neighbor_node_id(int current_node_id, SpacePoint **nodes_directions, double angle,
+    __device__ int get_neighbor_node_id(int current_node_id, SpacePoint *nodes_directions, double angle,
                                         bool *does_face_have_nodes, bool create_new_nodes);
 
 

--- a/src/SpacePoint.cu
+++ b/src/SpacePoint.cu
@@ -50,6 +50,14 @@ __host__ __device__ SpacePoint operator%(SpacePoint a, SpacePoint b)
     return {a.y * b.z - a.z * b.y, a.z * b.x - a.x * b.z, a.x * b.y - a.y * b.x};
 }
 
+__host__ __device__ double operator^(SpacePoint a, SpacePoint b)
+{
+    double l_a = get_distance(a, origin), l_b = get_distance(b, origin), l_c = get_distance(b - a, origin);
+    double cos_a = (l_a * l_a + l_b * l_b - l_c * l_c) / (2 * l_a * l_b);
+
+    return l_a * l_b * sqrt(1 - cos_a * cos_a);
+}
+
 
 __host__ __device__ SpacePoint relative_point_rotation(SpacePoint a, SpacePoint b, SpacePoint normal, double angle)
 {

--- a/src/SpacePoint.cuh
+++ b/src/SpacePoint.cuh
@@ -102,6 +102,18 @@ __host__ __device__ double operator*(SpacePoint a, SpacePoint b);
  */
 __host__ __device__ SpacePoint operator%(SpacePoint a, SpacePoint b);
 
+/**
+ * Returns the pseudo-scalar (skew) product of two vectors
+ *
+ * @param a Point in space, vector
+ * @param b Point in space, vector
+ *
+ * @note Pseudo-scalar product is an area of parallelogram defined by two vectors
+ *
+ * @returns Pseudo-scalar product of two vectors in 3D
+ */
+__host__ __device__ double operator^(SpacePoint a, SpacePoint b);
+
 
 /**
  * Rotates point B relative to point A along the face with given normal

--- a/src/common.cuh
+++ b/src/common.cuh
@@ -36,30 +36,6 @@ __host__ __device__ static T *malloc_and_copy(const T *source, int count)
     return new_array;
 }
 
-/**
- * Creates new array with `new_size`, moves source to it, frees up source memory
- *
- * @tparam T Type of the array
- *
- * @param source Pointer to an array to reallocate
- * @param old_size Size of the source array
- * @param new_size Size of new array
- *
- * @note old_size must be less than or equal to new_size
- *
- * @returns Pointer to the created array
- */
-template<class T>
-__host__ __device__ static T *device_realloc(T *source, int old_size, int new_size)
-{
-    T *new_array = (T *)malloc(new_size * sizeof(T));
-    for(int i = 0; i < old_size; ++i)
-    {
-        new_array[i] = std::move(source[i]);
-    }
-    free(source);
-    return new_array;
-}
 
 /**
  * Swaps two given values

--- a/src/main_logic.cuh
+++ b/src/main_logic.cuh
@@ -266,46 +266,52 @@ __host__ inline Polyhedron generate_cube(double edge_length = 200)
             {0,           0, 0},
             {0,           0, edge_length},
             {edge_length, 0, edge_length},
-            {edge_length, 0, 0}
+            {edge_length, 0, 0},
+            {0,           0, 0}
     };
     SpacePoint vertices2[] = {
             {0, 0,           0},
             {0, edge_length, 0},
             {0, edge_length, edge_length},
-            {0, 0,           edge_length}
+            {0, 0,           edge_length},
+            {0, 0,           0}
     };
     SpacePoint vertices3[] = {
             {0,           0,           0},
             {edge_length, 0,           0},
             {edge_length, edge_length, 0},
-            {0,           edge_length, 0}
+            {0,           edge_length, 0},
+            {0,           0,           0}
     };
     SpacePoint vertices4[] = {
             {edge_length, 0,           edge_length},
             {edge_length, edge_length, edge_length},
             {edge_length, edge_length, 0},
-            {edge_length, 0,           0}
+            {edge_length, 0,           0},
+            {edge_length, 0,           edge_length}
     };
     SpacePoint vertices5[] = {
             {0,           0,           edge_length},
             {0,           edge_length, edge_length},
             {edge_length, edge_length, edge_length},
-            {edge_length, 0,           edge_length}
+            {edge_length, 0,           edge_length},
+            {0,           0,           edge_length}
     };
     SpacePoint vertices6[] = {
             {edge_length, edge_length, 0},
             {edge_length, edge_length, edge_length},
             {0,           edge_length, edge_length},
-            {0,           edge_length, 0}
+            {0,           edge_length, 0},
+            {edge_length, edge_length, 0}
     };
 
     Face faces[] = {
-            Face(vertices1, 4),
-            Face(vertices2, 4),
-            Face(vertices3, 4),
-            Face(vertices4, 4),
-            Face(vertices5, 4),
-            Face(vertices6, 4)
+            Face(vertices1, 5),
+            Face(vertices2, 5),
+            Face(vertices3, 5),
+            Face(vertices4, 5),
+            Face(vertices5, 5),
+            Face(vertices6, 5)
     };
 
     Polyhedron cube(std::move(faces), 6);


### PR DESCRIPTION
The grid parallel to the cube edges is being created correctly now, due to direction vectors are perpendicular to the edges. Other grids still have problems with nodes creation.