### PR TITLE
Removed repetition of a vertex in `Face::vertices`

### DIFF
--- a/src/Face.cuh
+++ b/src/Face.cuh
@@ -35,10 +35,10 @@ public:
      *      Must be ordered in a special way (see note below)
      * @param n_of_vertices Number of vertices on the face
      *
-     * @note The vertices order. Looking on a face <b>from outside</b> the polyhedron, some vertex (let's call it A)
-     * must be saved to vertices[0]. It's neighbour clockwise - vertex B (B is next to A clockwise) must be saved to
-     * vertices[1] and so on. Assuming there are N vertices in total, A's neighbors are B clockwise and
-     * X counterclockwise, X must be saved to vertices[N - 2], and A must be saved <b>again</b> to vertices[N - 1]
+     * @note The vertices order matters: looking on a face <b>from outside</b> the polyhedron, some vertex (let's call
+     * it A) must be saved to `vertices[0]`. It's neighbour clockwise - vertex B (B is next to A clockwise) must be
+     * saved to `vertices[1]` and so on. Assuming there are N vertices in total, A's neighbors are B clockwise and
+     * X counterclockwise, X must be saved to `vertices[N - 1]`
      */
     __host__ __device__ Face(const SpacePoint *vertices, int n_of_vertices);
 

--- a/src/Polyhedron.cu
+++ b/src/Polyhedron.cu
@@ -95,8 +95,8 @@ __host__ __device__ Face *find_face_next_to_edge(int vertex_id, Face *current_fa
 {
     const SpacePoint *point_a = current_face->get_vertices() + vertex_id;
     const SpacePoint *point_b = point_a + 1; // By default it's just the next vertex
-    if(vertex_id + 1 == current_face->get_n_of_vertices()) // But if point_a was the last one
-        point_b = current_face->get_vertices(); // Then point b should be the first one
+    if(vertex_id + 1 == current_face->get_n_of_vertices()) // But if `point_a` was the last one
+        point_b = current_face->get_vertices(); // Then `point_b` should be the first one
 
     for(int i = 0; i < polyhedron->get_n_of_faces(); ++i)
         if(polyhedron->get_faces()[i] != *current_face &&
@@ -109,9 +109,8 @@ __host__ __device__ SpacePoint find_intersection_with_edge(SpacePoint a, SpacePo
                                                            int *intersection_edge)
 {
     int n_of_vertices = current_face->get_n_of_vertices();
-    const SpacePoint *vertices = current_face->get_vertices();
 
-    for(int i = 0; i < current_face->get_n_of_vertices(); ++i)
+    for(int i = 0; i < n_of_vertices; ++i)
     {
         SpacePoint intersection = line_intersection(current_face->get_vertices()[i],
                                                     current_face->get_vertices()[(i + 1) % n_of_vertices], a, b);

--- a/src/Polyhedron.cu
+++ b/src/Polyhedron.cu
@@ -93,11 +93,14 @@ __host__ __device__ bool does_edge_belong_to_face(SpacePoint a, SpacePoint b, co
 
 __host__ __device__ Face *find_face_next_to_edge(int vertex_id, Face *current_face, Polyhedron *polyhedron)
 {
+    const SpacePoint *point_a = current_face->get_vertices() + vertex_id;
+    const SpacePoint *point_b = point_a + 1; // By default it's just the next vertex
+    if(vertex_id + 1 == current_face->get_n_of_vertices()) // But if point_a was the last one
+        point_b = current_face->get_vertices(); // Then point b should be the first one
+
     for(int i = 0; i < polyhedron->get_n_of_faces(); ++i)
         if(polyhedron->get_faces()[i] != *current_face &&
-                does_edge_belong_to_face(current_face->get_vertices()[vertex_id],
-                                         current_face->get_vertices()[vertex_id + 1],
-                                         &polyhedron->get_faces()[i]))
+                does_edge_belong_to_face(*point_a, *point_b, &polyhedron->get_faces()[i]))
             return &polyhedron->get_faces()[i];
     return current_face;
 }
@@ -105,12 +108,16 @@ __host__ __device__ Face *find_face_next_to_edge(int vertex_id, Face *current_fa
 __host__ __device__ SpacePoint find_intersection_with_edge(SpacePoint a, SpacePoint b, Face *current_face,
                                                            int *intersection_edge)
 {
-    for(int i = 0; i < current_face->get_n_of_vertices() - 1; ++i)
+    int n_of_vertices = current_face->get_n_of_vertices();
+    const SpacePoint *vertices = current_face->get_vertices();
+
+    for(int i = 0; i < current_face->get_n_of_vertices(); ++i)
     {
         SpacePoint intersection = line_intersection(current_face->get_vertices()[i],
-                                                    current_face->get_vertices()[i + 1], a, b);
+                                                    current_face->get_vertices()[(i + 1) % n_of_vertices], a, b);
         if(intersection != origin && is_in_segment(a, b, intersection) &&
-                is_in_segment(current_face->get_vertices()[i], current_face->get_vertices()[i + 1], intersection) &&
+                is_in_segment(current_face->get_vertices()[i], current_face->get_vertices()[(i + 1) % n_of_vertices],
+                              intersection) &&
                 get_distance(intersection, a) > eps)
         {
             if(intersection_edge != nullptr)

--- a/src/Polyhedron.cuh
+++ b/src/Polyhedron.cuh
@@ -93,7 +93,7 @@ __host__ __device__ bool does_edge_belong_to_face(SpacePoint a, SpacePoint b, co
 
 /**
  * Finds a face adjacent to the given face along the edge represented by vertices
- * with indexes `vertex_id` and `vertex_id + 1` in `Face::vertices` array
+ * with indexes `vertex_id` and `(vertex_id + 1) % current_face->get_n_of_vertices()` in `Face::vertices` array
  *
  * @param vertex_id Index of edge vertex in `Face::vertices` array
  * @param current_face Pointer to the face to search next to


### PR DESCRIPTION
Removed requirement to repeat the first vertex of a face to be duplicated at the end of `vertices` array for the `Face` class and updated related functions to work correctly with the new way of storing vertices

Should fix #19 in an even better way, than suggested in the issue (I hope)