### PR TITLE
Workflow improvements

### DIFF
--- a/.github/workflows/ubuntu_build.yml
+++ b/.github/workflows/ubuntu_build.yml
@@ -59,9 +59,9 @@ jobs:
       if: success() && steps.steps_skiper.outputs.SKIP_STEPS != 'true'
       run: |
         sudo apt-get install -y gcc-${{ matrix.gcc }} g++-${{ matrix.gcc }}
-        echo "::set-env name=CC::/usr/bin/gcc-${{ matrix.gcc }}"
-        echo "::set-env name=CXX::/usr/bin/g++-${{ matrix.gcc }}"
-        echo "::set-env name=CUDAHOSTCXX::/usr/bin/g++-${{ matrix.gcc }}"
+        echo "CC=/usr/bin/gcc-${{ matrix.gcc }}" >> $GITHUB_ENV
+        echo "CXX=/usr/bin/g++-${{ matrix.gcc }}" >> $GITHUB_ENV
+        echo "CUDAHOSTCXX=/usr/bin/g++-${{ matrix.gcc }}" >> $GITHUB_ENV
 
     - name: Install CUDA
       if: success() && steps.steps_skiper.outputs.SKIP_STEPS != 'true'
@@ -69,7 +69,7 @@ jobs:
         ./scripts/actions/install_cuda_${{ matrix.cuda }}.sh
         sudo ln -s /usr/local/cuda* /usr/local/cuda
         /usr/local/cuda/bin/nvcc -V
-        echo "::add-path::/usr/local/cuda/bin/"
+        echo "/usr/local/cuda/bin/" >> $GITHUB_PATH
 
 
     - name: Build project

--- a/.github/workflows/ubuntu_build.yml
+++ b/.github/workflows/ubuntu_build.yml
@@ -24,7 +24,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-20.04, ubuntu-18.04, ubuntu-16.04]
-        cuda: ["11.0", "10.2", "10.1", "10.0"]
+        cuda: ["11.1", "11.0", "10.2", "10.1", "10.0"]
         gcc: [8, 7, 6]
         exclude:
           # Cuda 10.0 doesn't support Ubuntu 20.04

--- a/scripts/actions/install_cuda_11.1.sh
+++ b/scripts/actions/install_cuda_11.1.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -e
+
+UBUNTU_VERSION="$(lsb_release -sr)"
+UBUNTU_VERSION="${UBUNTU_VERSION//.}"
+
+wget -q "https://developer.download.nvidia.com/compute/cuda/repos/ubuntu$UBUNTU_VERSION/x86_64/cuda-ubuntu$UBUNTU_VERSION.pin" -O cuda.pin
+sudo mv cuda.pin /etc/apt/preferences.d/cuda-repository-pin-600
+wget -q "http://developer.download.nvidia.com/compute/cuda/11.1.0/local_installers/cuda-repo-ubuntu$UBUNTU_VERSION-11-1-local_11.1.0-455.23.05-1_amd64.deb" -O cuda-repo.deb
+sudo dpkg -i cuda-repo.deb
+sudo apt-key add "/var/cuda-repo-ubuntu$UBUNTU_VERSION-11-1-local/7fa2af80.pub"
+sudo apt update
+sudo apt -y install cuda-{compiler,libraries{,-dev}}-11-1
+
+/usr/local/cuda-11.1/bin/nvcc -V


### PR DESCRIPTION
- Added cuda 11.1 tests
- `add-path` and `set-env` [are deprecated and will be removed soon](https://github.com/actions/toolkit/security/advisories/GHSA-mfwh-5m23-j46w). This PR replaces them with the [new syntax](https://github.com/actions/toolkit/blob/main/docs/commands.md#environment-files)