### PR TITLE
Hash set

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ set(CMAKE_CXX_STANDARD 14)
 set(SOURCES src/main_logic/simulation_logic.cu src/external/random_generator.cu src/simulation_objects/SimulationMap.cu
         src/simulation_objects/geometric/Polyhedron.cu src/simulation_objects/Particle.cu
         src/simulation_objects/MapNode.cu src/simulation_objects/geometric/SpacePoint.cu
-        src/simulation_objects/geometric/Face.cu src/external/visualization_integration.cu)
+        src/simulation_objects/geometric/Face.cu src/external/visualization_integration.cu src/external/HashSet.cuh)
 
 option(COMPILE_FOR_CPU "Make produced executable run on CPU instead of GPU" OFF)
 

--- a/src/external/HashSet.cuh
+++ b/src/external/HashSet.cuh
@@ -1,0 +1,93 @@
+#ifndef MINDS_CRAWL_HASHSET_CUH
+#define MINDS_CRAWL_HASHSET_CUH
+
+
+#include <functional>
+
+#include "../simulation_objects/SimulationMap.cuh"
+
+
+/**
+ * Very simple implementation of hash set (which should consume memory as hell because of using same number of
+ * elements per bucket)
+ *
+ * Implementation of hash set which only supports adding elements and checking if an element was added to it. Uses same
+ * bucket size for each bucket. Undefined behaviour if trying to add more than `max_bucket_size` elements to one bucket
+ *
+ * @tparam T Type of the container's element
+ */
+template<class T>
+class HashSet
+{
+public:
+    /**
+     * Constructor of `HashSet`
+     *
+     * @param buckets_count Number of buckets to be created for the container's elements
+     * @param max_bucket_size Number of elements can be stored in the same bucket
+     * @param hasher_func Function accepting `const T &` and returning its hash as `unsigned long long`.
+     *      Should be `__host__ __device__`, undefined behaviour otherwise
+     */
+    explicit __host__ __device__ HashSet(size_t buckets_count, size_t max_bucket_size,
+                                         unsigned long long (*hasher_func)(const T &))
+            : sizes_of_buckets((size_t *)malloc(buckets_count * sizeof(size_t))),
+              elements((T *)malloc(buckets_count * max_bucket_size * sizeof(T))),
+              max_bucket_size(max_bucket_size), buckets_count(buckets_count), hasher(hasher_func)
+    {
+        memset((void *)sizes_of_buckets, 0, buckets_count);
+    }
+
+    /**
+     * Add element to the container
+     *
+     * @param elem Element to be added
+     * @returns `true` if the element was added, `false` otherwise (which means the element was in the container
+     *      already)
+     */
+    __host__ __device__ bool add(const T &elem)
+    {
+        unsigned long long hash = hasher(elem);
+        size_t bucket_index = hash % buckets_count;
+
+        for(size_t i = 0; i < sizes_of_buckets[bucket_index]; ++i)
+        {
+            if(elements[bucket_index * max_bucket_size + i] == elem)
+                return false;
+        }
+
+        elements[bucket_index * max_bucket_size + sizes_of_buckets[bucket_index]++] = elem;
+        return true;
+    }
+
+    /**
+     * Checks if an element is present in the container
+     *
+     * @param elem Element to search for
+     * @returns `true` if the element is in the container, `false` otherwise
+     */
+    __host__ __device__ bool contains(const T &elem)
+    {
+        size_t hash = hasher(elem);
+        size_t bucket_index = hash % buckets_count;
+
+        for(size_t i = 0; i < sizes_of_buckets[bucket_index]; ++i)
+        {
+            if(elements[bucket_index * max_bucket_size + i] == elem)
+                return true;
+        }
+
+        return false;
+    }
+
+private:
+    T *elements;
+    size_t *sizes_of_buckets;
+
+    size_t buckets_count;
+    size_t max_bucket_size;
+
+    unsigned long long (*hasher)(const T &);
+};
+
+
+#endif //MINDS_CRAWL_HASHSET_CUH

--- a/src/simulation_objects/SimulationMap.cu
+++ b/src/simulation_objects/SimulationMap.cu
@@ -12,6 +12,8 @@ namespace jc = jones_constants;
 
 __device__ const double mapnode_dist = 2 * jc::speed;
 
+__host__ __device__ static unsigned long long hash(const SpacePoint &value);
+
 
 __device__ SimulationMap::SimulationMap(Polyhedron *polyhedron) :
         polyhedron(polyhedron)
@@ -262,4 +264,28 @@ __global__ void get_n_of_nodes(const SimulationMap *const simulation_map, int *r
     STOP_ALL_THREADS_EXCEPT_FIRST;
 
     *return_value = simulation_map->get_n_of_nodes();
+}
+
+
+__host__ __device__ static unsigned long long hash(const double &value)
+{
+    static_assert(sizeof(double) == sizeof(unsigned long long),
+                  "Hash function implementation won't work correctly if `sizeof(double)` is not equal to "
+                  "`sizeof(unsigned long long)`");
+
+    union
+    {
+        double d;
+        unsigned long long ull;
+    } hasher{value};
+    return hasher.ull;
+}
+
+__host__ __device__ static unsigned long long hash(const SpacePoint &value)
+{
+    unsigned long long ans = 17;
+    ans = ans * 31 + hash(value.x);
+    ans = ans * 31 + hash(value.y);
+    ans = ans * 31 + hash(value.z);
+    return ans;
 }

--- a/src/simulation_objects/SimulationMap.cu
+++ b/src/simulation_objects/SimulationMap.cu
@@ -7,21 +7,19 @@
 #include "../jones_constants.hpp"
 #include "../external/random_generator.cuh"
 
-
-typedef bool(MapNode::*SetNodeMethod)(MapNode *);
-
-typedef MapNode *(MapNode::*GetNodeMethod)() const;
-
-
 namespace jc = jones_constants;
 
 
-__device__ double const mapnode_dist = 2 * jc::speed;
+__device__ const double mapnode_dist = 2 * jc::speed;
 
 
 __device__ SimulationMap::SimulationMap(Polyhedron *polyhedron) :
         polyhedron(polyhedron)
 {
+    typedef bool(MapNode::*SetNodeMethod)(MapNode *);
+    typedef MapNode *(MapNode::*GetNodeMethod)() const;
+
+
     /*
      * Maximum number of nodes
      * It must be greater than or equal to the real number of nodes (`n_of_nodes`) after creation node grid


### PR DESCRIPTION
Implemented a very simple version of hash set using pointer-represented arrays, having the same size for each bucket. Added hash functions for `double` (which just interprets `double` as `unsigned long long`) and for `SpacePoint`