### PR TITLE
Fixed bug of point projection on polyhedron's surface

### DIFF
--- a/src/simulation_objects/SimulationMap.cu
+++ b/src/simulation_objects/SimulationMap.cu
@@ -38,8 +38,11 @@ __device__ SimulationMap::SimulationMap(Polyhedron *polyhedron) :
     nodes[0] = MapNode(polyhedron, start_face, start_node_coordinates);
     n_of_nodes = 1;
 
-    // Direction vector parallel to the vertical edges of cube
-    SpacePoint direction_vector = {0, 0, 1};
+    // Direction vector of the first node to the top neighbor
+    SpacePoint direction_vector = relative_point_rotation(start_node_coordinates, start_face->get_vertices()[0],
+                                                          start_face->get_normal(), M_PI * 2 * rand0to1()) -
+                                  start_node_coordinates;
+
     /**
      * Array of direction vectors from nodes with the same index
      * as in `SimulationMap::nodes` array to their top neighbors

--- a/src/simulation_objects/geometric/Polyhedron.cu
+++ b/src/simulation_objects/geometric/Polyhedron.cu
@@ -132,12 +132,13 @@ __host__ __device__ SpacePoint find_intersection_with_edge(SpacePoint a, SpacePo
 
     for(int i = 0; i < n_of_vertices; ++i)
     {
-        SpacePoint intersection = line_intersection(current_face->get_vertices()[i],
-                                                    current_face->get_vertices()[(i + 1) % n_of_vertices], a, b);
-        if(intersection != origin && is_in_segment(a, b, intersection) &&
-                is_in_segment(current_face->get_vertices()[i], current_face->get_vertices()[(i + 1) % n_of_vertices],
-                              intersection) &&
-                get_distance(intersection, a) > eps)
+        SpacePoint intersection = origin;
+        bool is_parallel = line_intersection(current_face->get_vertices()[i],
+                                             current_face->get_vertices()[(i + 1) % n_of_vertices],
+                                             a, b, &intersection);
+        if(!is_parallel && is_in_segment(a, b, intersection) &&
+           is_in_segment(current_face->get_vertices()[i], current_face->get_vertices()[(i + 1) % n_of_vertices],
+                         intersection) && get_distance(intersection, a) > eps)
         {
             if(intersection_edge != nullptr)
             {

--- a/src/simulation_objects/geometric/Polyhedron.cu
+++ b/src/simulation_objects/geometric/Polyhedron.cu
@@ -133,10 +133,10 @@ __host__ __device__ SpacePoint find_intersection_with_edge(SpacePoint a, SpacePo
     for(int i = 0; i < n_of_vertices; ++i)
     {
         SpacePoint intersection = origin;
-        bool is_parallel = do_lines_intersect(current_face->get_vertices()[i],
-                                              current_face->get_vertices()[(i + 1) % n_of_vertices],
-                                              a, b, &intersection);
-        if(!is_parallel && is_in_segment(a, b, intersection) &&
+        bool are_parallel = are_lines_parallel(current_face->get_vertices()[i],
+                                               current_face->get_vertices()[(i + 1) % n_of_vertices],
+                                               a, b, &intersection);
+        if(!are_parallel && is_in_segment(a, b, intersection) &&
            is_in_segment(current_face->get_vertices()[i], current_face->get_vertices()[(i + 1) % n_of_vertices],
                          intersection) && get_distance(intersection, a) > eps)
         {

--- a/src/simulation_objects/geometric/Polyhedron.cu
+++ b/src/simulation_objects/geometric/Polyhedron.cu
@@ -133,9 +133,9 @@ __host__ __device__ SpacePoint find_intersection_with_edge(SpacePoint a, SpacePo
     for(int i = 0; i < n_of_vertices; ++i)
     {
         SpacePoint intersection = origin;
-        bool is_parallel = line_intersection(current_face->get_vertices()[i],
-                                             current_face->get_vertices()[(i + 1) % n_of_vertices],
-                                             a, b, &intersection);
+        bool is_parallel = do_lines_intersect(current_face->get_vertices()[i],
+                                              current_face->get_vertices()[(i + 1) % n_of_vertices],
+                                              a, b, &intersection);
         if(!is_parallel && is_in_segment(a, b, intersection) &&
            is_in_segment(current_face->get_vertices()[i], current_face->get_vertices()[(i + 1) % n_of_vertices],
                          intersection) && get_distance(intersection, a) > eps)
@@ -150,11 +150,9 @@ __host__ __device__ SpacePoint find_intersection_with_edge(SpacePoint a, SpacePo
     return b;
 }
 
-__host__ __device__ SpacePoint get_projected_vector_end(SpacePoint a, SpacePoint b, Face *current_face,
-                                                        Polyhedron *polyhedron)
+__host__ __device__ SpacePoint get_projected_vector_end(SpacePoint vector_start, SpacePoint vector_end,
+                                                        Face *current_face, Polyhedron *polyhedron)
 {
-    SpacePoint vector_start = a;
-    SpacePoint vector_end = b;
     int intersection_edge_vertex_id = 0;
     SpacePoint intersection = find_intersection_with_edge(vector_start, vector_end, current_face,
                                                           &intersection_edge_vertex_id);

--- a/src/simulation_objects/geometric/Polyhedron.cuh
+++ b/src/simulation_objects/geometric/Polyhedron.cuh
@@ -135,15 +135,15 @@ __host__ __device__ SpacePoint find_intersection_with_edge(SpacePoint a, SpacePo
  * If vector AB completely lies on the current face of polyhedron, coordinates of point B are returned
  * If vector AB crosses the edge of current face, the end of overlay on the next face to edge is returned
  *
- * @param a The beginning of vector AB, point A
- * @param b The end of vector AB, point B
+ * @param vector_start The beginning of vector AB, point A
+ * @param vector_end The end of vector AB, point B
  * @param current_face Pointer to the face point A belongs to
  * @param polyhedron The polyhedron in simulation
  *
  * @returns Coordinates of the end of AB vector's overlay
  */
-__host__ __device__ SpacePoint get_projected_vector_end(SpacePoint a, SpacePoint b, Face *current_face,
-                                                        Polyhedron *polyhedron);
+__host__ __device__ SpacePoint get_projected_vector_end(SpacePoint vector_start, SpacePoint vector_end,
+                                                        Face *current_face, Polyhedron *polyhedron);
 
 
 #endif //MINDS_CRAWL_POLYHEDRON_CUH

--- a/src/simulation_objects/geometric/SpacePoint.cu
+++ b/src/simulation_objects/geometric/SpacePoint.cu
@@ -1,5 +1,6 @@
 #ifdef COMPILE_FOR_CPU
 #include <cmath>
+#include <utility>
 #endif //COMPILE_FOR_CPU
 
 #include "SpacePoint.cuh"
@@ -73,7 +74,8 @@ __host__ __device__ double get_distance(SpacePoint a, SpacePoint b)
     return sqrt((a.x - b.x) * (a.x - b.x) + (a.y - b.y) * (a.y - b.y) + (a.z - b.z) * (a.z - b.z));
 }
 
-__host__ __device__ SpacePoint line_intersection(SpacePoint a, SpacePoint b, SpacePoint c, SpacePoint d)
+__host__ __device__ bool line_intersection(SpacePoint a, SpacePoint b, SpacePoint c, SpacePoint d,
+                                           SpacePoint *intersection)
 {
     SpacePoint direction_vectorAB = (b - a) / get_distance(b - a, origin);
     SpacePoint direction_vectorCD = (d - c) / get_distance(d - c, origin);
@@ -85,14 +87,15 @@ __host__ __device__ SpacePoint line_intersection(SpacePoint a, SpacePoint b, Spa
     double k_origin_dist = get_distance(k, origin);
 
     if(h_origin_dist < eps || k_origin_dist < eps)
-        return origin;
+        return true;
     else
     {
         SpacePoint l = direction_vectorAB * h_origin_dist / k_origin_dist;
         if((h * k) / (h_origin_dist * k_origin_dist) > 0)
-            return a + l;
+            *intersection = a + l;
         else
-            return a - l;
+            *intersection = a - l;
+        return false;
     }
 }
 

--- a/src/simulation_objects/geometric/SpacePoint.cu
+++ b/src/simulation_objects/geometric/SpacePoint.cu
@@ -1,7 +1,8 @@
 #ifdef COMPILE_FOR_CPU
 #include <cmath>
-#include <utility>
 #endif //COMPILE_FOR_CPU
+
+#include <utility>
 
 #include "SpacePoint.cuh"
 
@@ -65,7 +66,7 @@ __host__ __device__ SpacePoint relative_point_rotation(SpacePoint a, SpacePoint 
     double angle_cos = cos(angle);
     SpacePoint radius = b - a;
     return (1 - angle_cos) * (normal * radius) * normal + angle_cos * radius +
-            sin(angle) * (normal % radius) + a;
+           sin(angle) * (normal % radius) + a;
 }
 
 
@@ -74,8 +75,8 @@ __host__ __device__ double get_distance(SpacePoint a, SpacePoint b)
     return sqrt((a.x - b.x) * (a.x - b.x) + (a.y - b.y) * (a.y - b.y) + (a.z - b.z) * (a.z - b.z));
 }
 
-__host__ __device__ bool line_intersection(SpacePoint a, SpacePoint b, SpacePoint c, SpacePoint d,
-                                           SpacePoint *intersection)
+__host__ __device__ bool do_lines_intersect(SpacePoint a, SpacePoint b, SpacePoint c, SpacePoint d,
+                                            SpacePoint *intersection)
 {
     SpacePoint direction_vectorAB = (b - a) / get_distance(b - a, origin);
     SpacePoint direction_vectorCD = (d - c) / get_distance(d - c, origin);

--- a/src/simulation_objects/geometric/SpacePoint.cu
+++ b/src/simulation_objects/geometric/SpacePoint.cu
@@ -2,8 +2,6 @@
 #include <cmath>
 #endif //COMPILE_FOR_CPU
 
-#include <utility>
-
 #include "SpacePoint.cuh"
 
 
@@ -75,7 +73,7 @@ __host__ __device__ double get_distance(SpacePoint a, SpacePoint b)
     return sqrt((a.x - b.x) * (a.x - b.x) + (a.y - b.y) * (a.y - b.y) + (a.z - b.z) * (a.z - b.z));
 }
 
-__host__ __device__ bool do_lines_intersect(SpacePoint a, SpacePoint b, SpacePoint c, SpacePoint d,
+__host__ __device__ bool are_lines_parallel(SpacePoint a, SpacePoint b, SpacePoint c, SpacePoint d,
                                             SpacePoint *intersection)
 {
     SpacePoint direction_vectorAB = (b - a) / get_distance(b - a, origin);

--- a/src/simulation_objects/geometric/SpacePoint.cuh
+++ b/src/simulation_objects/geometric/SpacePoint.cuh
@@ -2,6 +2,8 @@
 #define MINDS_CRAWL_SPACEPOINT_CUH
 
 
+#include <utility>
+
 /// Object describing a point in 3d space
 struct SpacePoint
 {
@@ -139,16 +141,19 @@ __host__ __device__ SpacePoint relative_point_rotation(SpacePoint a, SpacePoint 
 __host__ __device__ double get_distance(SpacePoint a, SpacePoint b);
 
 /**
- * Returns the point of lines AB and CD intersection or origin if they are parallel
+ * Checks whether lines AB and CD are parallel or not
+ * Saves point of two lines intersection to `intersection` if lines are not parallel
  *
  * @param a Point A belongs to the line AB
  * @param b Point B belongs to the line AB
  * @param c Point C belongs to the line CD
  * @param d Point D belongs to the line CD
+ * @param intersection Pointer to `SpacePoint` where the point of lines intersection save to
  *
- * @returns The point of two lines intersection or origin if they are parallel
+ * @returns `true` if lines are parallel, `false` otherwise
  */
-__host__ __device__ SpacePoint line_intersection(SpacePoint a, SpacePoint b, SpacePoint c, SpacePoint d);
+__host__ __device__ bool line_intersection(SpacePoint a, SpacePoint b, SpacePoint c, SpacePoint d,
+                                           SpacePoint *intersection);
 
 /**
  * Checks if the point C is in segment AB

--- a/src/simulation_objects/geometric/SpacePoint.cuh
+++ b/src/simulation_objects/geometric/SpacePoint.cuh
@@ -2,8 +2,6 @@
 #define MINDS_CRAWL_SPACEPOINT_CUH
 
 
-#include <utility>
-
 /// Object describing a point in 3d space
 struct SpacePoint
 {
@@ -152,8 +150,8 @@ __host__ __device__ double get_distance(SpacePoint a, SpacePoint b);
  *
  * @returns `true` if lines are parallel, `false` otherwise
  */
-__host__ __device__ bool line_intersection(SpacePoint a, SpacePoint b, SpacePoint c, SpacePoint d,
-                                           SpacePoint *intersection);
+__host__ __device__ bool do_lines_intersect(SpacePoint a, SpacePoint b, SpacePoint c, SpacePoint d,
+                                            SpacePoint *intersection);
 
 /**
  * Checks if the point C is in segment AB

--- a/src/simulation_objects/geometric/SpacePoint.cuh
+++ b/src/simulation_objects/geometric/SpacePoint.cuh
@@ -150,7 +150,7 @@ __host__ __device__ double get_distance(SpacePoint a, SpacePoint b);
  *
  * @returns `true` if lines are parallel, `false` otherwise
  */
-__host__ __device__ bool do_lines_intersect(SpacePoint a, SpacePoint b, SpacePoint c, SpacePoint d,
+__host__ __device__ bool are_lines_parallel(SpacePoint a, SpacePoint b, SpacePoint c, SpacePoint d,
                                             SpacePoint *intersection);
 
 /**


### PR DESCRIPTION
When vector AB needs to be projected on polyhedron, sometimes its projection crosses more edges than one and lies on more faces than one or two. Previously, it was checked only once (whether vector AB intersects edges of face or not), so in some cases projected point B did not belong to the polyhedron's surface
That is fixed in this PR