### PR TITLE
Minor README issues fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,14 +28,14 @@ cmake .. -DCMAKE_BUILD_TYPE=Debug -DCOMPILE_FOR_CPU=ON
 cmake --build . -- -j`nproc`
 ```
 
-### Executing
+## Executing
 To run the application, you have to:
 
 1.  Start a visualization app (we recommend [this one](https://github.com/physarumAdv/Physarum_webGL))
 
 2.  Create a directory `config` in the process's **working directory** with a file `visualization_endpoint.txt` inside
-it, containing 2 urls which accepts the simulated data (One url for particles and one for polyhedron. An example is in
-[local/visualization_endpoint_example.txt](config/visualization_endpoint_example.txt))
+it, containing 2 urls which accepts the simulated data (the first url for particles and the second for polyhedron. An example is
+in [config/visualization_endpoint_example.txt](config/visualization_endpoint_example.txt))
 
 ## Authors
 


### PR DESCRIPTION
- Fixed a typo making the `Executing` section a subsection of `Compiling`
- Slightly clarified the format of config/visualization_endpoint.txt
- Fixed the link to config/visualization_endpoint_example.txt