### PR TITLE
Cuda visualization integration fix

### DIFF
--- a/src/external/visualization_integration.cu
+++ b/src/external/visualization_integration.cu
@@ -76,8 +76,8 @@ __host__ bool send_poly_to_visualization(const std::pair<std::string, std::strin
     return true;
 }
 
-__host__ bool send_particles_to_visualization(const std::pair<std::string, std::string> &urls, const MapNode *nodes,
-                                              int n_of_nodes)
+__host__ bool send_particles_to_visualization(const std::pair<std::string, std::string> &urls,
+                                              const MapNodeReflection *nodes, int n_of_nodes)
 {
     std::vector<double> x, y, z;
     x.reserve(n_of_nodes);
@@ -86,13 +86,13 @@ __host__ bool send_particles_to_visualization(const std::pair<std::string, std::
 
     for(int i = 0; i < n_of_nodes; ++i)
     {
-        if(!nodes[i].does_contain_particle())
+        if(!nodes[i].contains_particle)
             continue;
 
-        Particle *p = nodes[i].get_particle();
-        x.push_back(p->coordinates.x);
-        y.push_back(p->coordinates.y);
-        z.push_back(p->coordinates.z);
+        SpacePoint coords = nodes[i].particle_coordinates;
+        x.push_back(coords.x);
+        y.push_back(coords.y);
+        z.push_back(coords.z);
     }
 
     std::string body = "{";

--- a/src/external/visualization_integration.cuh
+++ b/src/external/visualization_integration.cuh
@@ -56,8 +56,8 @@ __host__ std::string vector_double_to_json_array(const std::vector<double> &v);
  */
 __host__ bool send_poly_to_visualization(const std::pair<std::string, std::string> &urls, const Polyhedron *polyhedron);
 
-__host__ bool send_particles_to_visualization(const std::pair<std::string, std::string> &urls, const MapNode *nodes,
-                                              int n_of_nodes);
+__host__ bool send_particles_to_visualization(const std::pair<std::string, std::string> &urls,
+                                              const MapNodeReflection *nodes, int n_of_nodes);
 
 
 #endif //MINDS_CRAWL_VISUALIZATION_INTEGRATION_CUH

--- a/src/main_logic/iterations_wrapper.cuh
+++ b/src/main_logic/iterations_wrapper.cuh
@@ -117,10 +117,8 @@ __global__ void destruct_simulation_objects(Polyhedron *const polyhedron, Simula
  *
  * @see run_iteration_diffuse_trail, run_iteration_process_particles, run_iteration_cleanup
  *
- * @note Again, this function only processes just one node. To use it, you'll need
- *
- * @note This function is a part of run_iteration kernels set. Because at some moments while running an iteration we
- *      have to synchronize all the threads (including inside blocks), the "run_iteration" operation is split into
+ * @note This function is a part of run_iteration kernel. Because at some moments while running an iteration we
+ *      have to synchronize all the threads (including among blocks), the "run_iteration" operation is split into
  *      multiple kernel functions. Other functions (hopefully, all of them) are mentioned in the "see" block above
  */
 __device__ inline void run_iteration_project_nutrients(SimulationMap *const simulation_map,
@@ -170,8 +168,8 @@ __device__ inline void run_iteration_project_nutrients(SimulationMap *const simu
  *
  * @see run_iteration_project_nutrients, run_iteration_process_particles, run_iteration_cleanup
  *
- * @note This function is a part of run_iteration kernels set. Because at some moments while running an iteration we
- *      have to synchronize all the threads (including inside blocks), the "run_iteration" operation is split into
+ * @note This function is a part of run_iteration kernel. Because at some moments while running an iteration we
+ *      have to synchronize all the threads (including among blocks), the "run_iteration" operation is split into
  *      multiple kernel functions. Other functions (hopefully, all of them) are mentioned in the "see" block above
  */
 __device__ inline void run_iteration_diffuse_trail(SimulationMap *const simulation_map,
@@ -196,8 +194,8 @@ __device__ inline void run_iteration_diffuse_trail(SimulationMap *const simulati
  *
  * @see run_iteration_project_nutrients, run_iteration_diffuse_trail, run_iteration_cleanup
  *
- * @note This function is a part of run_iteration kernels set. Because at some moments while running an iteration we
- *      have to synchronize all the threads (including inside blocks), the "run_iteration" operation is split into
+ * @note This function is a part of run_iteration kernel. Because at some moments while running an iteration we
+ *      have to synchronize all the threads (including among blocks), the "run_iteration" operation is split into
  *      multiple kernel functions. Other functions (hopefully, all of them) are mentioned in the "see" block above
  */
 __device__ inline void run_iteration_process_particles(SimulationMap *const simulation_map,
@@ -236,8 +234,8 @@ __device__ inline void run_iteration_process_particles(SimulationMap *const simu
  *
  * @see run_iteration_project_nutrients, run_iteration_diffuse_trail, run_iteration_process_particles
  *
- * @note This function is a part of run_iteration kernels set. Because at some moments while running an iteration we
- *      have to synchronize all the threads (including inside blocks), the "run_iteration" operation is split into
+ * @note This function is a part of run_iteration kernel. Because at some moments while running an iteration we
+ *      have to synchronize all the threads (including among blocks), the "run_iteration" operation is split into
  *      multiple kernel functions. Other functions (hopefully, all of them) are mentioned in the "see" block above
  */
 __device__ inline void run_iteration_cleanup(SimulationMap *const simulation_map, int *const iteration_number,

--- a/src/main_logic/main.cpp
+++ b/src/main_logic/main.cpp
@@ -2,7 +2,7 @@
 #include <cstdlib>
 
 #include "simulation_logic.cuh"
-#include "iterations_wrapper.cuh"
+#include "simulation_motor.cuh"
 #include "../external/visualization_integration.cuh"
 
 

--- a/src/main_logic/main.cpp
+++ b/src/main_logic/main.cpp
@@ -30,6 +30,13 @@ void wrapped_run_iteration_cleanup(SimulationMap *const simulation_map, int *con
         run_iteration_cleanup(simulation_map, iteration_number, i);
 }
 
+// The result is stored in the `reflections` array
+void get_mapnodes_reflections(SimulationMap *const simulation_map, MapNodeReflection *reflections)
+{
+    for(unsigned int i = 0; i < simulation_map->get_n_of_nodes(); ++i)
+        reflections[i] = get_mapnode_reflection(simulation_map, i);
+}
+
 
 int main()
 {

--- a/src/main_logic/main.cpp
+++ b/src/main_logic/main.cpp
@@ -51,6 +51,10 @@ int main()
 
     int iteration_number = 0; // Incremented inside of `run_iteration_cleanup`
 
+    int n_of_nodes = simulation_map->get_n_of_nodes();
+    auto *mapnodes_reflections = (MapNodeReflection *)malloc(n_of_nodes * sizeof(MapNodeReflection));
+
+
     RunIterationFunc iteration_runners[] = {(RunIterationFunc)wrapped_run_iteration_project_nutrients,
                                             (RunIterationFunc)wrapped_run_iteration_diffuse_trail,
                                             (RunIterationFunc)wrapped_run_iteration_process_particles,
@@ -68,12 +72,14 @@ int main()
     if(!polyhedronDispatchFailed)
     {
         while (true) {
+            get_mapnodes_reflections(simulation_map, mapnodes_reflections);
+
             for (RunIterationFunc f : iteration_runners) {
                 f(simulation_map, &iteration_number);
             }
 
-            if (!send_particles_to_visualization(visualization_endpoints, simulation_map->nodes,
-                                                 simulation_map->get_n_of_nodes())) {
+            if(!send_particles_to_visualization(visualization_endpoints, mapnodes_reflections, n_of_nodes))
+            {
                 std::cerr << "Error sending http request to visualization. Stopping the simulation process\n";
                 break;
             }

--- a/src/main_logic/main.cu
+++ b/src/main_logic/main.cu
@@ -150,10 +150,18 @@ __host__ int main()
     cudaMallocManaged(&mapnodes_reflections, n_of_nodes * sizeof(MapNodeReflection));
 
     bool modelDispatchFailed = false;
-    if(!send_poly_to_visualization(visualization_endpoints, polyhedron))
     {
-        std::cerr << "Error sending http request to visualization. Stopping the simulation process\n";
-        modelDispatchFailed = true;
+        // Please, pay attention! This is a very ugly and temporary solution for
+        // https://github.com/physarumAdv/minds_crawl/issues/47. I know some ways to implement it much better, but
+        // I don't want to loose time on doing this now, because it's still unclear for me how we're going to import
+        // polyhedrons in future, so the way to send polyhedron I might have chosen could be incompatible with the way
+        // we import polyhedrons. That's why now I just create another cube and send it instead of the original one
+        Polyhedron temp_poly = generate_cube();
+        if(!send_poly_to_visualization(visualization_endpoints, &temp_poly))
+        {
+            std::cerr << "Error sending http request to visualization. Stopping the simulation process\n";
+            modelDispatchFailed = true;
+        }
     }
 
     if(cudaPeekAtLastError() == cudaSuccess && !modelDispatchFailed)

--- a/src/main_logic/main.cu
+++ b/src/main_logic/main.cu
@@ -2,7 +2,7 @@
 #include <iostream>
 
 #include "simulation_logic.cuh"
-#include "iterations_wrapper.cuh"
+#include "simulation_motor.cuh"
 #include "../external/visualization_integration.cuh"
 #include "../external/random_generator.cuh"
 

--- a/src/main_logic/main.cu
+++ b/src/main_logic/main.cu
@@ -41,6 +41,14 @@ __global__ void wrapped_run_iteration_cleanup(SimulationMap *const simulation_ma
     run_iteration_cleanup(simulation_map, iteration_number, i);
 }
 
+// The result is stored in the `reflections` array
+__global__ void get_mapnodes_reflections(const SimulationMap *const simulation_map, MapNodeReflection *reflections)
+{
+    unsigned int i = blockIdx.x * blockDim.x + threadIdx.x;
+
+    reflections[i] = get_mapnode_reflection(simulation_map, i);
+}
+
 
 /**
  * Sets a device-allocated variable to a given value from host code

--- a/src/main_logic/main.cu
+++ b/src/main_logic/main.cu
@@ -45,6 +45,8 @@ __global__ void wrapped_run_iteration_cleanup(SimulationMap *const simulation_ma
 __global__ void get_mapnodes_reflections(const SimulationMap *const simulation_map, MapNodeReflection *reflections)
 {
     unsigned int i = blockIdx.x * blockDim.x + threadIdx.x;
+    if(i >= simulation_map->get_n_of_nodes())
+        return;
 
     reflections[i] = get_mapnode_reflection(simulation_map, i);
 }
@@ -159,7 +161,8 @@ __host__ int main()
         while(true)
         {
             // Reflect `MapNode`s (in fact, defer to previous stream operations completion)
-            get_mapnodes_reflections<<<1, 1, 0, iterations_stream>>>(simulation_map, mapnodes_reflections);
+            get_mapnodes_reflections<<<cuda_grid_size, cuda_block_size, 0, iterations_stream>>>(simulation_map,
+                                                                                                mapnodes_reflections);
 
             // Wait for all the operations in the stream to finish
             if(cudaStreamSynchronize(iterations_stream) != cudaSuccess)

--- a/src/main_logic/simulation_logic.cu
+++ b/src/main_logic/simulation_logic.cu
@@ -127,7 +127,7 @@ __device__ void division_test(MapNode *node)
 }
 
 
-__device__ Polyhedron generate_cube(double edge_length)
+__host__ __device__ Polyhedron generate_cube(double edge_length)
 {
     SpacePoint vertices1[] = {
             {0,           0, 0},

--- a/src/main_logic/simulation_logic.cuh
+++ b/src/main_logic/simulation_logic.cuh
@@ -130,7 +130,7 @@ __device__ void division_test(MapNode *node);
  *
  * @returns Cube represented wth a `Polyhedron` object
  */
-__device__ Polyhedron generate_cube(double edge_length = 200);
+__host__ __device__ Polyhedron generate_cube(double edge_length = 200);
 
 
 #endif //MIND_S_CRAWL_FUCKING_SHIT_CUH

--- a/src/main_logic/simulation_motor.cuh
+++ b/src/main_logic/simulation_motor.cuh
@@ -1,7 +1,9 @@
 /**
  * The file contains functions initializing a simulation and its environment and functions from the run_iteration kernel
  * which is a set of functions which together perform an iteration in the simulation. It might contain other functions
- * related to a similar functionality and behaving in a similar way.
+ * related to things main should do when running the simulation. It shouldn't, however, for example, contain any
+ * structures or functions any other file may want: this file should only be included to main.cpp and main.cu and used
+ * for things which are common for these two files, so we take it out here to reduce code duplication
  *
  * Each of the run_iteration functions defined here only works with one node by its index, so you'll need to wrap them
  * and call them for each node
@@ -263,25 +265,6 @@ __device__ inline void run_iteration_cleanup(SimulationMap *const simulation_map
         ++*iteration_number;
 }
 
-
-/**
- * Object describing a state of a `MapNode` in the simulation. It has no methods or private fields and does not point to
- * any memory area, which allows to freely copy or move the object, including between host and device memory
- */
-struct MapNodeReflection
-{
-    /// Trail value
-    double trail;
-
-    /// Coordinates of the node
-    SpacePoint node_coordinates;
-
-    /// Whether the node contains a particle or not
-    bool contains_particle;
-
-    /// The particle's coordinates if there is any (if `.contains_particle`), undefined otherwise
-    SpacePoint particle_coordinates;
-};
 
 /**
  * Reflects a `MapNode` with the given index and returns a `MapNodeReflection` object

--- a/src/main_logic/simulation_motor.cuh
+++ b/src/main_logic/simulation_motor.cuh
@@ -264,4 +264,44 @@ __device__ inline void run_iteration_cleanup(SimulationMap *const simulation_map
 }
 
 
+/**
+ * Object describing a state of a `MapNode` in the simulation. It has no methods or private fields and does not point to
+ * any memory area, which allows to freely copy or move the object, including between host and device memory
+ */
+struct MapNodeReflection
+{
+    /// Trail value
+    double trail;
+
+    /// Coordinates of the node
+    SpacePoint node_coordinates;
+
+    /// Whether the node contains a particle or not
+    bool contains_particle;
+
+    /// The particle's coordinates if there is any (if `.contains_particle`), undefined otherwise
+    SpacePoint particle_coordinates;
+};
+
+/**
+ * Reflects a `MapNode` with the given index and returns a `MapNodeReflection` object
+ *
+ * @param simulation_map `SimulationMap` object to get a node from
+ * @param node_index Index of the `MapNode` to reflect
+ * @returns Reflection of the node
+ */
+__device__ inline MapNodeReflection get_mapnode_reflection(const SimulationMap *const simulation_map,
+                                                           const unsigned int node_index)
+{
+    MapNode &node = simulation_map->nodes[node_index];
+
+    MapNodeReflection reflection{.trail = node.trail, .node_coordinates = node.get_coordinates(),
+            .contains_particle = node.does_contain_particle()};
+    if(reflection.contains_particle)
+        reflection.particle_coordinates = node.get_particle()->coordinates;
+
+    return reflection;
+}
+
+
 #endif //MINDS_CRAWL_MAIN_LOGIC_CUH

--- a/src/main_logic/simulation_motor.cuh
+++ b/src/main_logic/simulation_motor.cuh
@@ -1,3 +1,13 @@
+/**
+ * The file contains functions initializing a simulation and its environment and functions from the run_iteration kernel
+ * which is a set of functions which together perform an iteration in the simulation. It might contain other functions
+ * related to a similar functionality and behaving in a similar way.
+ *
+ * Each of the run_iteration functions defined here only works with one node by its index, so you'll need to wrap them
+ * and call them for each node
+ */
+
+
 #ifndef MINDS_CRAWL_MAIN_LOGIC_CUH
 #define MINDS_CRAWL_MAIN_LOGIC_CUH
 

--- a/src/simulation_objects/MapNode.cuh
+++ b/src/simulation_objects/MapNode.cuh
@@ -346,4 +346,24 @@ __host__ __device__ MapNode *find_nearest_mapnode(const Polyhedron *polyhedron, 
                                                   MapNode *start = nullptr);
 
 
+/**
+ * Object describing a state of a `MapNode` in the simulation. It has no methods or private fields and does not point to
+ * any memory area, which allows to freely copy or move the object, including between host and device memory
+ */
+struct MapNodeReflection
+{
+    /// Trail value
+    double trail;
+
+    /// Coordinates of the node
+    SpacePoint node_coordinates;
+
+    /// Whether the node contains a particle or not
+    bool contains_particle;
+
+    /// The particle's coordinates if there is any (if `.contains_particle`), undefined otherwise
+    SpacePoint particle_coordinates;
+};
+
+
 #endif //MINDS_CRAWL_MAPNODE_CUH


### PR DESCRIPTION
Fixed the inability to send anything to visualization when compiled for GPU. `Polyhedron` is still sent not in the best way, definitely, but I don't think it's worth spending time on a better implementation before we add a mechanism of using polyhedrons different from cube

Fixes #47
Is blocked by #51 (current PR is based on some commits from the `fixed_some_logic_bugs` branch)