### PR TITLE
Removed the `diffuse_trail` function, moved its body to `run_iteration_diffuse_trail`

### DIFF
--- a/src/main_logic/simulation_logic.cu
+++ b/src/main_logic/simulation_logic.cu
@@ -37,18 +37,6 @@ namespace jc = jones_constants;
 }
 
 
-__host__ __device__ void diffuse_trail(MapNode *node)
-{
-    auto left = node->get_left(), top = node->get_top(), right = node->get_right(), bottom = node->get_bottom();
-
-    double sum = top->get_left()->trail + top->trail + top->get_right()->trail +
-                 left->trail + node->trail + right->trail +
-                 bottom->get_left()->trail + bottom->trail + bottom->get_right()->trail;
-
-    node->temp_trail = (1 - jc::diffdamp) * (sum / 9.0);
-}
-
-
 __host__ __device__ int count_particles_in_node_window(MapNode *node, int window_size)
 {
     for(int i = 0; i < window_size / 2; ++i)

--- a/src/main_logic/simulation_logic.cuh
+++ b/src/main_logic/simulation_logic.cuh
@@ -35,19 +35,6 @@
 [[nodiscard]] __device__ bool delete_particle(MapNode *node);
 
 /**
- * Diffuses trail in the given node
- *
- * The diffusion algorithm (developed by Jeff Jones) is pretty simple at first sight. We calculate an average
- * `trail` value in a 3x3 node window around the given one and multiply it by `(1 - jones_constants::diffdamp)`.
- * The new `temp_trail` value in the given node is the value just calculated. This is a natural way to implement the
- * smell spread: on each iteration smell moves more far from the source, but becomes less strong, because
- * `(1 - jones_constants::diffdamp)` < 1
- *
- * @param node Pointer to the node to diffuse trail at
- */
-__host__ __device__ void diffuse_trail(MapNode *node);
-
-/**
  * Returns number of particles in a node window around the given node
  *
  * Let's assume a node of the model is a plane point with coordinates (X, Y). Then it's neighbors (even if they are not

--- a/src/main_logic/simulation_motor.cuh
+++ b/src/main_logic/simulation_motor.cuh
@@ -192,7 +192,13 @@ __device__ inline void run_iteration_diffuse_trail(SimulationMap *const simulati
     MapNode *self;
     RUN_ITERATION_SET_SELF(self, node_index)
 
-    diffuse_trail(self);
+    auto left = self->get_left(), top = self->get_top(), right = self->get_right(), bottom = self->get_bottom();
+
+    double sum = top->get_left()->trail + top->trail + top->get_right()->trail +
+                 left->trail + self->trail + right->trail +
+                 bottom->get_left()->trail + bottom->trail + bottom->get_right()->trail;
+
+    self->temp_trail = (1 - jc::diffdamp) * (sum / 9.0);
 }
 
 /**


### PR DESCRIPTION
I don't see why this should be a separate function. It is never called from any other place (and it shouldn't be); `run_iteration_project_nutrients` (which is similar to `run_iteration_diffuse_trail`) contains its code just in its body. Moreover, the documentation block about the diffusion algorithm was duplicated